### PR TITLE
Route markdown images through atc-api and refresh deps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.0
-# Updated: 27-11-2025
+# Version: 1.0.1
+# Updated: 20-04-2026
 # Location: Root
 # Distribution: DotNet10
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
@@ -441,28 +441,24 @@ dotnet_naming_rule.parameters_rule.severity             = warning
 # http://www.asyncfixer.com
 
 
-# Asyncify
-# https://github.com/hvanbakel/Asyncify-CSharp
-
-
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
-dotnet_diagnostic.MA0003.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0003.md
-dotnet_diagnostic.MA0004.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0004.md
-dotnet_diagnostic.MA0006.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0006.md
+dotnet_diagnostic.MA0003.severity = suggestion      # Add argument name to improve readability
+dotnet_diagnostic.MA0004.severity = suggestion      # Use Task.ConfigureAwait(false)
+dotnet_diagnostic.MA0006.severity = none            # Use String.Equals instead of equality operator
 dotnet_diagnostic.MA0011.severity = none            # Duplicate of CA1305
-dotnet_diagnostic.MA0016.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0016.md
-dotnet_diagnostic.MA0025.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0025.md
-dotnet_diagnostic.MA0026.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0026.md
-dotnet_diagnostic.MA0028.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0028.md
+dotnet_diagnostic.MA0016.severity = error           # Prefer return collection abstraction over implementation
+dotnet_diagnostic.MA0025.severity = suggestion      # Implement functionality instead of throwing NotImplementedException
+dotnet_diagnostic.MA0026.severity = suggestion      # Fix TODO comment
+dotnet_diagnostic.MA0028.severity = none            # Optimize StringBuilder usage
 dotnet_diagnostic.MA0038.severity = none            # Duplicate of CA1822
-dotnet_diagnostic.MA0048.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0048.md
+dotnet_diagnostic.MA0048.severity = error           # File name must match type name
 
 
 # Microsoft - Code Analysis
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/
-dotnet_diagnostic.CA1014.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1014.md
-dotnet_diagnostic.CA1068.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1068.md
+dotnet_diagnostic.CA1014.severity = none            # Mark assemblies with CLSCompliantAttribute
+dotnet_diagnostic.CA1068.severity = error           # CancellationToken parameters must come last
 dotnet_diagnostic.CA1305.severity = error
 dotnet_diagnostic.CA1308.severity = suggestion      # Normalize strings to uppercase
 dotnet_diagnostic.CA1510.severity = suggestion      # Use ArgumentNullException throw helper
@@ -471,7 +467,7 @@ dotnet_diagnostic.CA1512.severity = suggestion      # Use ArgumentOutOfRangeExce
 dotnet_diagnostic.CA1513.severity = suggestion      # Use ObjectDisposedException throw helper
 dotnet_diagnostic.CA1514.severity = error           # Avoid redundant length argument
 dotnet_diagnostic.CA1515.severity = suggestion      # Because an application's API isn't typically referenced from outside the assembly, types can be made internal (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1515)
-dotnet_diagnostic.CA1707.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1707.md
+dotnet_diagnostic.CA1707.severity = error           # Identifiers should not contain underscores
 dotnet_diagnostic.CA1812.severity = none
 dotnet_diagnostic.CA1822.severity = suggestion
 dotnet_diagnostic.CA1849.severity = error           # Call async methods when in an async method
@@ -498,7 +494,7 @@ dotnet_diagnostic.CA1873.severity = suggestion      # Avoid potentially expensiv
 dotnet_diagnostic.CA1874.severity = suggestion      # Use 'Regex.IsMatch' instead of 'Regex.Match(...).Success' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1874)
 dotnet_diagnostic.CA1875.severity = suggestion      # Use 'Regex.Count' instead of 'Regex.Matches(...).Count' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1875)
 dotnet_diagnostic.CA1877.severity = suggestion      # Use 'Path.Combine' or 'Path.Join' overloads (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1877)
-dotnet_diagnostic.CA2007.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA2007.md
+dotnet_diagnostic.CA2007.severity = suggestion      # Do not directly await a Task
 dotnet_diagnostic.CA2017.severity = error           # Parameter count mismatch
 dotnet_diagnostic.CA2018.severity = error           # The count argument to Buffer.BlockCopy should specify the number of bytes to copy
 dotnet_diagnostic.CA2019.severity = error           # ThreadStatic fields should not use inline initialization
@@ -515,12 +511,12 @@ dotnet_diagnostic.CA2262.severity = suggestion      # Set 'MaxResponseHeadersLen
 dotnet_diagnostic.CA2263.severity = suggestion      # Prefer generic overload when type is known
 dotnet_diagnostic.CA2264.severity = error           # Do not pass a non-nullable value to 'ArgumentNullException.ThrowIfNull'
 dotnet_diagnostic.CA2265.severity = error           # Do not compare Sp an<T> to 'null' or 'default' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2265)
-dotnet_diagnostic.IDE0005.severity = warning        # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/IDE0005.md
+dotnet_diagnostic.IDE0005.severity = warning        # Remove unnecessary using directives
 dotnet_diagnostic.IDE0010.severity = suggestion     # Populate switch
 dotnet_diagnostic.IDE0028.severity = suggestion     # Collection initialization can be simplified
 dotnet_diagnostic.IDE0021.severity = suggestion     # Use expression body for constructor
 dotnet_diagnostic.IDE0055.severity = none           # Fix formatting
-dotnet_diagnostic.IDE0058.severity = none           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/IDE0058.md
+dotnet_diagnostic.IDE0058.severity = none           # Remove unnecessary expression value
 dotnet_diagnostic.IDE0061.severity = suggestion     # Use expression body for local function
 dotnet_diagnostic.IDE0130.severity = suggestion     # Namespace does not match folder structure
 dotnet_diagnostic.IDE0290.severity = none			# Use primary constructor
@@ -530,38 +526,34 @@ dotnet_diagnostic.IDE0305.severity = suggestion     # Collection initialization 
 
 # Microsoft - Compiler Errors
 # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/
-dotnet_diagnostic.CS4014.severity = error          # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCompilerErrors/CS4014.md
-
-
-# SecurityCodeScan
-# https://security-code-scan.github.io/
+dotnet_diagnostic.CS4014.severity = error           # Call is not awaited
 
 
 # StyleCop
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers
-dotnet_diagnostic.SA1009.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1009.md
+dotnet_diagnostic.SA1009.severity = none            # Closing parenthesis should be spaced correctly
 dotnet_diagnostic.SA1010.severity = none            # False positive when using collection initializers
-dotnet_diagnostic.SA1101.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1101.md
-dotnet_diagnostic.SA1122.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1122.md
-dotnet_diagnostic.SA1133.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1133.md
-dotnet_diagnostic.SA1200.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1200.md
-dotnet_diagnostic.SA1201.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1201.md
-dotnet_diagnostic.SA1202.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1202.md
-dotnet_diagnostic.SA1204.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1204.md
-dotnet_diagnostic.SA1413.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1413.md
-dotnet_diagnostic.SA1600.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1600.md
+dotnet_diagnostic.SA1101.severity = none            # Prefix local calls with this
+dotnet_diagnostic.SA1122.severity = error           # Use string.Empty for empty strings
+dotnet_diagnostic.SA1133.severity = error           # Do not combine attributes
+dotnet_diagnostic.SA1200.severity = none            # Using directives should be placed correctly
+dotnet_diagnostic.SA1201.severity = none            # Elements should appear in the correct order
+dotnet_diagnostic.SA1202.severity = none            # Elements should be ordered by access
+dotnet_diagnostic.SA1204.severity = none            # Static elements should appear before instance elements
+dotnet_diagnostic.SA1413.severity = error           # Use trailing commas in multi-line initializers
+dotnet_diagnostic.SA1600.severity = none            # Elements should be documented
 dotnet_diagnostic.SA1601.severity = none
-dotnet_diagnostic.SA1602.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1602.md
-dotnet_diagnostic.SA1604.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1604.md
-dotnet_diagnostic.SA1623.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1623.md
-dotnet_diagnostic.SA1629.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1629.md
-dotnet_diagnostic.SA1633.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1633.md
-dotnet_diagnostic.SA1649.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1649.md
+dotnet_diagnostic.SA1602.severity = none            # Enumeration items should be documented
+dotnet_diagnostic.SA1604.severity = none            # Element documentation should have summary
+dotnet_diagnostic.SA1623.severity = none            # Property summary documentation should match accessors
+dotnet_diagnostic.SA1629.severity = none            # Documentation text should end with a period
+dotnet_diagnostic.SA1633.severity = none            # File should have header
+dotnet_diagnostic.SA1649.severity = error           # File name should match first type name
 
 
 # SonarAnalyzer.CSharp
 # https://rules.sonarsource.com/csharp
-dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/SonarAnalyzerCSharp/S1135.md
+dotnet_diagnostic.S1135.severity = suggestion       # Track uses of TODO tags
 dotnet_diagnostic.S2629.severity = none            	# Don't use string interpolation in logging message templates.
 dotnet_diagnostic.S3358.severity = none           	# Extract this nested ternary operation into an independent statement.
 dotnet_diagnostic.S6602.severity = none           	# "Find" method should be used instead of the "FirstOrDefault"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,13 +39,11 @@
 
   <!-- Shared code analyzers used for all projects in the solution -->
   <ItemGroup Label="Code Analyzers">
-    <PackageReference Include="Atc.Analyzer" Version="0.1.22" PrivateAssets="All" />
+    <PackageReference Include="Atc.Analyzer" Version="0.1.23" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
-    <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.29" PrivateAssets="All" />
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.58" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.22.0.136894" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.25.0.139117" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.0
-# Updated: 27-11-2025
+# Version: 1.0.1
+# Updated: 20-04-2026
 # Location: src
 # Distribution: DotNet10
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
@@ -14,10 +14,6 @@
 # http://www.asyncfixer.com
 
 
-# Asyncify
-# https://github.com/hvanbakel/Asyncify-CSharp
-
-
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
 
@@ -28,10 +24,6 @@
 
 # Microsoft - Compiler Errors
 # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/
-
-
-# SecurityCodeScan
-# https://security-code-scan.github.io/
 
 
 # StyleCop

--- a/src/AtcWeb.Domain/.editorconfig
+++ b/src/AtcWeb.Domain/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.1
-# Updated: 03-06-2024
+# Version: 1.0.2
+# Updated: 19-04-2026
 # Location: blazor
 # Distribution: Frameworks
 
@@ -17,6 +17,10 @@ dotnet_diagnostic.BL0003.severity = error           # Component parameter with C
 dotnet_diagnostic.BL0004.severity = error           # Component parameter should be public - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0004?view=aspnetcore-8.0
 dotnet_diagnostic.BL0005.severity = error           # Component parameter should not be set outside of its component - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0005?view=aspnetcore-8.0
 dotnet_diagnostic.BL0006.severity = warning         # Do not use RenderTree types - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0006?view=aspnetcore-8.0
+dotnet_diagnostic.BL0007.severity = warning         # Component parameter should be auto property - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0007?view=aspnetcore-10.0
+dotnet_diagnostic.BL0008.severity = warning         # Component parameters should be auto properties ([SupplyParameterFromForm] with non-default initializer) - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0008?view=aspnetcore-10.0
+dotnet_diagnostic.BL0009.severity = warning         # Property initializer can be overwritten for [PersistentState] properties - https://github.com/dotnet/aspnetcore/pull/63236
+dotnet_diagnostic.BL0010.severity = warning         # Use InvokeVoidAsync for JavaScript functions that don't return a value - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0010?view=aspnetcore-11.0
 
 dotnet_diagnostic.MA0048.severity = none            # To support code-behind [component].razor.cs files / Inherit from ComponentBase - File will not match type name.
 

--- a/src/AtcWeb.Domain/AtcApi/AtcApiUrlBuilder.cs
+++ b/src/AtcWeb.Domain/AtcApi/AtcApiUrlBuilder.cs
@@ -1,0 +1,39 @@
+namespace AtcWeb.Domain.AtcApi;
+
+public static class AtcApiUrlBuilder
+{
+    private static readonly HashSet<string> AllowedExternalProxyOwners = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "atc-net",
+        "microsoft",
+        "dotnet",
+        "Azure",
+        "github",
+    };
+
+    [SuppressMessage("Design", "CA1055:URI-like return values should not be strings", Justification = "Consumed directly as an HTML attribute value.")]
+    public static string BuildRawFileUrl(
+        string repositoryName,
+        string branch,
+        string filePath)
+        => $"{AtcApiConstants.BaseAddress}/github/repository/{Uri.EscapeDataString(repositoryName)}/raw?branch={Uri.EscapeDataString(branch)}&filePath={Uri.EscapeDataString(filePath)}";
+
+    [SuppressMessage("Design", "CA1055:URI-like return values should not be strings", Justification = "Consumed directly as an HTML attribute value.")]
+    public static string BuildExternalRawFileUrl(
+        string owner,
+        string repositoryName,
+        string branch,
+        string filePath)
+        => $"{AtcApiConstants.BaseAddress}/github/raw/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repositoryName)}?branch={Uri.EscapeDataString(branch)}&filePath={Uri.EscapeDataString(filePath)}";
+
+    [SuppressMessage("Design", "CA1055:URI-like return values should not be strings", Justification = "Consumed directly as an HTML attribute value.")]
+    public static string BuildAvatarUrl(
+        long userId,
+        int? size = null)
+        => size.HasValue
+            ? $"{AtcApiConstants.BaseAddress}/github/users/{userId}/avatar?size={size.Value}"
+            : $"{AtcApiConstants.BaseAddress}/github/users/{userId}/avatar";
+
+    public static bool IsExternalProxyOwner(string owner)
+        => AllowedExternalProxyOwners.Contains(owner);
+}

--- a/src/AtcWeb.Domain/AtcWeb.Domain.csproj
+++ b/src/AtcWeb.Domain/AtcWeb.Domain.csproj
@@ -5,14 +5,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc" Version="3.0.18" />
-    <PackageReference Include="Atc.DotNet" Version="3.0.18" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
+    <PackageReference Include="Atc" Version="3.0.67" />
+    <PackageReference Include="Atc.DotNet" Version="3.0.67" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
     <PackageReference Include="Microsoft.Build.Framework" Version="18.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
 
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Atc.Analyzer" Version="0.1.23" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.203" />
   </ItemGroup>
 
 </Project>

--- a/src/AtcWeb/.editorconfig
+++ b/src/AtcWeb/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.1
-# Updated: 03-06-2024
+# Version: 1.0.2
+# Updated: 19-04-2026
 # Location: blazor
 # Distribution: Frameworks
 
@@ -9,7 +9,21 @@
 ##########################################
 [*.{cs}]
 
+dotnet_diagnostic.ASP0006.severity = suggestion     # Do not use non-literal sequence numbers - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/asp0006?view=aspnetcore-8.0
+
+dotnet_diagnostic.BL0001.severity = error           # Component parameter should have public setters - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0001?view=aspnetcore-8.0
+dotnet_diagnostic.BL0002.severity = error           # Component has multiple CaptureUnmatchedValues parameters - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0002?view=aspnetcore-8.0
+dotnet_diagnostic.BL0003.severity = error           # Component parameter with CaptureUnmatchedValues has the wrong type - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0003?view=aspnetcore-8.0
+dotnet_diagnostic.BL0004.severity = error           # Component parameter should be public - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0004?view=aspnetcore-8.0
+dotnet_diagnostic.BL0005.severity = error           # Component parameter should not be set outside of its component - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0005?view=aspnetcore-8.0
+dotnet_diagnostic.BL0006.severity = warning         # Do not use RenderTree types - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0006?view=aspnetcore-8.0
+dotnet_diagnostic.BL0007.severity = warning         # Component parameter should be auto property - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0007?view=aspnetcore-10.0
+dotnet_diagnostic.BL0008.severity = warning         # Component parameters should be auto properties ([SupplyParameterFromForm] with non-default initializer) - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0008?view=aspnetcore-10.0
+dotnet_diagnostic.BL0009.severity = warning         # Property initializer can be overwritten for [PersistentState] properties - https://github.com/dotnet/aspnetcore/pull/63236
+dotnet_diagnostic.BL0010.severity = warning         # Use InvokeVoidAsync for JavaScript functions that don't return a value - https://learn.microsoft.com/en-us/aspnet/core/diagnostics/bl0010?view=aspnetcore-11.0
+
 dotnet_diagnostic.MA0048.severity = none            # To support code-behind [component].razor.cs files / Inherit from ComponentBase - File will not match type name.
+
 
 ##########################################
 # Custom - Code Analyzers Rules

--- a/src/AtcWeb/AtcWeb.csproj
+++ b/src/AtcWeb/AtcWeb.csproj
@@ -9,22 +9,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc" Version="3.0.18" />
+    <PackageReference Include="Atc" Version="3.0.67" />
     <PackageReference Include="Atc.Blazor" Version="1.0.22" />
 <PackageReference Include="ColorCode.HTML" Version="2.0.15" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
-    <PackageReference Include="Markdig" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" PrivateAssets="all" />
+    <PackageReference Include="Markdig" Version="1.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.7" PrivateAssets="all" />
 <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="MudBlazor" Version="9.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageReference Include="MudBlazor" Version="9.4.0" />
 
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AtcWeb.Domain\AtcWeb.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Atc.Analyzer" Version="0.1.23" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.203" />
   </ItemGroup>
 
 </Project>

--- a/src/AtcWeb/Components/MarkdownRepositoryContent.razor.cs
+++ b/src/AtcWeb/Components/MarkdownRepositoryContent.razor.cs
@@ -138,23 +138,39 @@ public partial class MarkdownRepositoryContent : ComponentBase
     private MarkupString SanitizeHtmlToMarkup(string html)
     {
         const string hrefBase = "https://github.com/atc-net/";
-        const string imgSrcRaw = "https://raw.githubusercontent.com/atc-net/";
+        const string imgStyle = "max-width: 100%; height: auto;";
         var hrefRepo = $"{hrefBase}{RepositoryName}/blob/{RepositoryBranch}/";
         var hrefRepoTree = $"{hrefBase}{RepositoryName}/tree/{RepositoryBranch}/";
-        var imgRepoRaw = $"{imgSrcRaw}{RepositoryName}/{RepositoryBranch}/";
 
         var sanitizedHtml = HtmlSanitizer.Sanitize(html);
 
-        // Rewrite relative image sources to raw GitHub URLs
+        // Rewrite relative <img src="..."> to the atc-api raw-file proxy
         sanitizedHtml = Regex.Replace(
             sanitizedHtml,
-            @"<img src=""(?!https?://)([^""]+)""",
-            $@"<img style='max-width: 100%; height: auto;' src=""{imgRepoRaw}$1""",
+            @"<img src=""(?!https?://)(?:\./)?([^""]+)""",
+            m => $@"<img style='{imgStyle}' src=""{AtcApiUrlBuilder.BuildRawFileUrl(RepositoryName, RepositoryBranch, m.Groups[1].Value)}""",
             RegexOptions.None,
             TimeSpan.FromSeconds(5));
 
-        // Rewrite absolute github.com blob URLs in <img> tags to raw.githubusercontent.com
-        // (github.com/.../blob/... serves the HTML web view, not the image bytes)
+        // Rewrite absolute github.com/atc-net/{repo}/blob/{branch}/{path} <img> URLs to the proxy
+        sanitizedHtml = Regex.Replace(
+            sanitizedHtml,
+            @"<img src=""https://github\.com/atc-net/([^/""]+)/blob/([^/""]+)/([^""]+)""",
+            m => $@"<img style='{imgStyle}' src=""{AtcApiUrlBuilder.BuildRawFileUrl(m.Groups[1].Value, m.Groups[2].Value, m.Groups[3].Value)}""",
+            RegexOptions.None,
+            TimeSpan.FromSeconds(5));
+
+        // Rewrite absolute raw.githubusercontent.com/atc-net/{repo}/{branch}/{path} <img> URLs to the proxy
+        sanitizedHtml = Regex.Replace(
+            sanitizedHtml,
+            @"<img src=""https://raw\.githubusercontent\.com/atc-net/([^/""]+)/([^/""]+)/([^""]+)""",
+            m => $@"<img style='{imgStyle}' src=""{AtcApiUrlBuilder.BuildRawFileUrl(m.Groups[1].Value, m.Groups[2].Value, m.Groups[3].Value)}""",
+            RegexOptions.None,
+            TimeSpan.FromSeconds(5));
+
+        // Normalize non-atc-net github.com/{owner}/{repo}/blob/{branch}/{path} <img> URLs
+        // to raw.githubusercontent.com so the next step can apply a single routing rule.
+        // (github.com/.../blob/... serves the HTML web view, not the image bytes.)
         sanitizedHtml = Regex.Replace(
             sanitizedHtml,
             @"<img src=""https://github\.com/([^/""]+)/([^/""]+)/blob/([^""]+)""",
@@ -162,11 +178,25 @@ public partial class MarkdownRepositoryContent : ComponentBase
             RegexOptions.None,
             TimeSpan.FromSeconds(5));
 
-        // Add responsive styling to absolute raw.githubusercontent images
-        sanitizedHtml = sanitizedHtml.Replace(
-            "<img src=\"https://raw.githubusercontent.com/",
-            "<img style='max-width: 100%; height: auto;' src=\"https://raw.githubusercontent.com/",
-            StringComparison.Ordinal);
+        // Route remaining non-atc-net raw.githubusercontent.com images through the atc-api
+        // external proxy when the owner is allow-listed, otherwise leave the direct CDN URL
+        // in place. Responsive styling is applied either way.
+        sanitizedHtml = Regex.Replace(
+            sanitizedHtml,
+            @"<img src=""https://raw\.githubusercontent\.com/([^/""]+)/([^/""]+)/([^/""]+)/([^""]+)""",
+            m =>
+            {
+                var owner = m.Groups[1].Value;
+                var repo = m.Groups[2].Value;
+                var branch = m.Groups[3].Value;
+                var path = m.Groups[4].Value;
+                var src = AtcApiUrlBuilder.IsExternalProxyOwner(owner)
+                    ? AtcApiUrlBuilder.BuildExternalRawFileUrl(owner, repo, branch, path)
+                    : $"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}";
+                return $@"<img style='{imgStyle}' src=""{src}""";
+            },
+            RegexOptions.None,
+            TimeSpan.FromSeconds(5));
 
         // Rewrite relative src/ links to GitHub tree URLs
         sanitizedHtml = Regex.Replace(

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -51,7 +51,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
       <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" PrivateAssets="All" />
     </ItemGroup>
 </Project>

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.0
-# Updated: 27-11-2025
+# Version: 1.0.1
+# Updated: 20-04-2026
 # Location: test
 # Distribution: DotNet10
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
@@ -14,37 +14,30 @@
 # http://www.asyncfixer.com
 
 
-# Asyncify
-# https://github.com/hvanbakel/Asyncify-CSharp
-
-
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
-dotnet_diagnostic.MA0004.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0004.md
-dotnet_diagnostic.MA0016.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0016.md
+dotnet_diagnostic.MA0004.severity = none            # Use Task.ConfigureAwait(false)
+dotnet_diagnostic.MA0016.severity = none            # Prefer return collection abstraction over implementation
 dotnet_diagnostic.MA0051.severity = none            # Method Length
 
 
 # Microsoft - Code Analysis
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/
-dotnet_diagnostic.CA1068.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1068.md
-dotnet_diagnostic.CA1602.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1602.md
-dotnet_diagnostic.CA1707.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1707.md
-dotnet_diagnostic.CA2007.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA2007.md
+dotnet_diagnostic.CA1068.severity = none            # CancellationToken parameters must come last
+dotnet_diagnostic.CA1602.severity = none
+dotnet_diagnostic.CA1707.severity = none            # Identifiers should not contain underscores
+dotnet_diagnostic.CA2007.severity = none            # Do not directly await a Task
+dotnet_diagnostic.CA2025.severity = none            # Ensure tasks using 'IDisposable' instances complete before the instances are disposed
 
 
 # Microsoft - Compiler Errors
 # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/
 
 
-# SecurityCodeScan
-# https://security-code-scan.github.io/
-
-
 # StyleCop
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers
-dotnet_diagnostic.SA1122.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1122.md
-dotnet_diagnostic.SA1133.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1133.md
+dotnet_diagnostic.SA1122.severity = none            # Use string.Empty for empty strings
+dotnet_diagnostic.SA1133.severity = none            # Do not combine attributes
 
 
 # SonarAnalyzer.CSharp

--- a/test/AtcWeb.Domain.Tests/AtcWeb.Domain.Tests.csproj
+++ b/test/AtcWeb.Domain.Tests/AtcWeb.Domain.Tests.csproj
@@ -11,4 +11,11 @@
     <ProjectReference Include="..\..\src\AtcWeb\AtcWeb.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Atc.Analyzer" Version="0.1.23" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
+    <PackageReference Update="Microsoft.Testing.Extensions.TrxReport" Version="2.2.2" />
+  </ItemGroup>
+
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -13,9 +13,9 @@
   <ItemGroup>
     <PackageReference Include="Atc.Test" Version="2.0.17" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.2" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 


### PR DESCRIPTION
  # Summary

  - Route markdown images through the atc-api proxy where supported
  - Add atc-api URL helpers for the new external-raw and avatar endpoints
  - Refresh ATC coding rules and bump analyzers, runtime, and test deps

  # Changes

  ### :sparkles: Features
  - Add BuildExternalRawFileUrl, BuildAvatarUrl, IsExternalProxyOwner
  - Route atc-net markdown images through the repo-scoped proxy
  - Route allow-listed external owners through /github/raw proxy
  - Fall back to raw.githubusercontent.com for non-allow-listed owners

  ### :package: Dependencies
  - Bump Atc / Atc.DotNet 3.0.18 → 3.0.67
  - Bump ASP.NET WASM and Caching/Http extensions 10.0.5 → 10.0.7
  - Bump Markdig 1.1.2 → 1.1.3 and MudBlazor 9.2.0 → 9.4.0
  - Bump Microsoft.SourceLink.GitHub 10.0.201 → 10.0.203
  - Bump test SDK 18.5.1, CodeCoverage 18.6.2, TrxReport 2.2.2
  - Bump Atc.Analyzer 0.1.23, Meziantou 3.0.58, Sonar 10.25

  ### :wrench: Configuration
  - Update .editorconfig to atc-coding-rules 1.0.1 / Blazor 1.0.2
  - Add Blazor analyzers BL0007–BL0010 to the rule set

  ### :fire: Removal
  - Drop Asyncify and SecurityCodeScan rules from the rule set
